### PR TITLE
Show mouse display on hover

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -161,15 +161,15 @@ class vttThumbnailsPlugin {
   }
 
   setupThumbnailElement (data) {
-    const mouseDisplay = this.player.$('.vjs-mouse-display')
     this.progressBar = this.player.$('.vjs-progress-control')
     const thumbHolder = document.createElement('div')
     thumbHolder.setAttribute('class', 'vjs-vtt-thumbnail-display')
     this.progressBar.appendChild(thumbHolder)
     this.thumbnailHolder = thumbHolder
-    if(mouseDisplay) {
-      mouseDisplay.classList.add('vjs-hidden')
-    }
+    // const mouseDisplay = this.player.$('.vjs-mouse-display');
+    // if(mouseDisplay) {
+    //   mouseDisplay.classList.add('vjs-hidden')
+    // }
     this.registeredEvents.progressBarMouseEnter = () => { return this.onBarMouseenter() };
     this.registeredEvents.progressBarMouseLeave = () => { return this.onBarMouseleave() };
     this.progressBar.addEventListener('mouseenter', this.registeredEvents.progressBarMouseEnter)

--- a/src/plugin.scss
+++ b/src/plugin.scss
@@ -9,7 +9,7 @@
 
   .vjs-vtt-thumbnail-display {
     position: absolute;
-    transition: transform .1s, opacity .2s;
+    // transition: transform .1s, opacity .2s;
     bottom: 85%;
     pointer-events: none;
     box-shadow: 0 0 7px rgba(0,0,0,.6);


### PR DESCRIPTION
Minimal changes to match behavior of YouTube's player.
YouTube:
![youtube](https://user-images.githubusercontent.com/14208607/57142241-ac462e00-6d81-11e9-84d7-8fa47a19daae.png)

Video.js:
![invidious](https://user-images.githubusercontent.com/14208607/57142245-b10ae200-6d81-11e9-80b9-0d8081e62115.png)

The `transition: ..` line is commented out to prevent noticeable lag between mouse hover and thumbnail holder.

Since hiding the mouse display is intended behavior, I think it would probably make more sense to add this as an option when initializing the plugin, although I'm not sure how that should be handled.