### PR TITLE
Add note regarding support only for sprited thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # videojs-vtt-thumbnails
 
-Video.js plugin that displays thumbnails on progress bar hover, driven by external VTT files.  Based on the spec at: https://support.jwplayer.com/customer/portal/articles/1407439-adding-preview-thumbnails
+Video.js plugin that displays thumbnails on progress bar hover, driven by external VTT files.  Based on [this JW Player spec](https://support.jwplayer.com/customer/portal/articles/1407439-adding-preview-thumbnails). Note, this plugin currently only supports sprited thumbnails.
 
 Note: Plugin hides the default skin's mouse display timestamp on hover.
 


### PR DESCRIPTION
I learned the hard way that this module does not work with thumbnail-per-segment VTTs; it's better to do sprites anyway but the thumbnails will load but not appear (no dimensions are set for the applicable DOM node) unless the VTT file contains the `xywh` info.