### PR TITLE
add scale option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Note: Plugin hides the default skin's mouse display timestamp on hover.
   - [`<script>` Tag](#script-tag)
   - [Browserify/CommonJS](#browserifycommonjs)
   - [RequireJS/AMD](#requirejsamd)
+  - [Options](#options)
 - [License](#license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -69,6 +70,21 @@ require(['video.js', 'videojs-vtt-thumbnails'], function(videojs) {
   var player = videojs('my-video');
 
   player.vttThumbnails();
+});
+```
+
+### Options
+
+| Option  | Use | Default | Examples |
+| ------------- | ------------- | ------------- | ------------- |
+| `src`  | The VTT source file fro your thumbnails |  | `'example/thumbs.vtt'` |
+| `scale` | The scale factor applied to the thumbnail display | `1` | `0.5`, `1` |
+
+```js
+var player = videojs('my-video');
+player.vttThumbnails({
+  src: 'example/thumbs.vtt',
+  scale: 0.5
 });
 ```
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -349,11 +349,25 @@ class vttThumbnailsPlugin {
       return cssObj
     }
 
-    const imageProps = this.getPropsFromDef(vttImageDef)
-    cssObj.background = 'url("' + imageProps.image + '") no-repeat -' + imageProps.x + 'px -' + imageProps.y + 'px'
-    cssObj.width = imageProps.w + 'px'
-    cssObj.height = imageProps.h + 'px'
-    cssObj.url = imageProps.image
+    const imageProps = this.getPropsFromDef( vttImageDef );
+
+    let w = imageProps.w;
+    let h = imageProps.h;
+    let x = imageProps.x;
+    let y = imageProps.y;
+
+    if ( this.options.scale ) {
+      w = w * this.options.scale;
+      h = h * this.options.scale;
+      x = x * this.options.scale;
+      y = y * this.options.scale;
+    }
+
+    cssObj.background = 'url("' + imageProps.image + '") no-repeat -' + x + 'px -' + y + 'px';
+    cssObj.backgroundSize = '100%';
+    cssObj.width = w + 'px';
+    cssObj.height = h + 'px';
+    cssObj.url = imageProps.image;
 
     return cssObj
   }


### PR DESCRIPTION
Adding a `scale` option enables hi res thumbnails for high dpi displays.

Choosing which `.vtt` file is used when is not part of this change.
The plugin implementer should provide the correct source for the device screen.