### PR TITLE
If thumbnails overflow the video area, center it

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -287,7 +287,9 @@ class vttThumbnailsPlugin {
     const marginRight = width - (xPos + halfthumbnailWidth);
     const marginLeft = xPos - halfthumbnailWidth;
 
-    if (marginLeft > 0 && marginRight > 0) {
+    if (width < thumbnailWidth) {
+      this.thumbnailHolder.style.transform = 'translateX(' + (((thumbnailWidth - width) / 2) * -1) + 'px)';
+    } else if (marginLeft > 0 && marginRight > 0) {
       this.thumbnailHolder.style.transform = 'translateX(' + (xPos - halfthumbnailWidth) + 'px)';
     } else if (marginLeft <= 0) {
       this.thumbnailHolder.style.transform = 'translateX(' + 0 + 'px)';


### PR DESCRIPTION
If the thumbnails overflow the video area, center it.

![Screenshot from 2020-11-13 15-35-22](https://user-images.githubusercontent.com/58389183/99044412-b0841600-25ca-11eb-8dba-e6365dfaa07d.png)
