### PR TITLE
Use default export from package instead of named export version

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,5 +1,5 @@
 import videojs from 'video.js';
-import { version as VERSION } from '../package.json';
+import packageInfo from '../package.json';
 // import request from 'request';
 
 // Default options for the plugin.
@@ -502,6 +502,6 @@ class vttThumbnailsPlugin {
 registerPlugin('vttThumbnails', vttThumbnails);
 
 // Include the version number.
-vttThumbnails.VERSION = VERSION;
+vttThumbnails.VERSION = packageInfo.version;
 
 export default vttThumbnails;


### PR DESCRIPTION
Supports Webpack 5

[https://webpack.js.org/migrate/5/#cleanup-the-code](https://webpack.js.org/migrate/5/#cleanup-the-code)

> Using named exports from JSON modules: this is not supported by the new specification and you will get a warning. Instead of import { version } from './package.json' use import package from './package.json'; const { version } = package;

